### PR TITLE
Installation instructions added as a WP settings page

### DIFF
--- a/https-domain-alias.php
+++ b/https-domain-alias.php
@@ -4,8 +4,8 @@
  * Plugin Name: HTTPS domain alias
  * Plugin URI: https://github.com/Seravo/wp-https-domain-alias
  * Description: Enable your site to have a different domains for HTTP and HTTPS. Useful e.g. if you have a wildcard SSL/TLS certificate for server but not for each site.
- * Version: 0.8
- * Author: Otto Kekäläinen / Seravo Oy
+ * Version: 0.9
+ * Author: Otto Kekäläinen, Antti Kuosmanen / Seravo Oy
  * Author URI: http://seravo.fi
  * License: GPLv3
  */
@@ -181,4 +181,32 @@ function https_domain_alias_must_be_first_plugin() {
 }
 add_action('activated_plugin', 'https_domain_alias_must_be_first_plugin');
 
+/*
+ *
+ */
+
+// create a readme page in the settings menu
+add_action('admin_menu', 'https_domain_alias_readme');
+
+function https_domain_alias_readme() {
+
+	add_options_page('HTTPS Domain Alias', 'HTTPS Domain Alias', 'administrator', __FILE__, 'build_readme_page', plugins_url('/images/icon.png', __FILE__));
+
+}
+
+function build_readme_page() {
 ?>
+
+<div class="wrap">
+
+	<h2>HTTPS Domain Alias</h2>
+
+	<?php include('readme.html'); ?>
+
+	<p>&nbsp;</p>
+
+	<p>HTTPS Domain Alias version 0.9 by <a href="http://seravo.fi/">Seravo Oy</a>.</small>
+
+</div>
+
+<?php } ?>

--- a/readme.html
+++ b/readme.html
@@ -1,0 +1,51 @@
+<h3>Installation</h3>
+
+<ol>
+	<li>Upload `https-domain-alias.php` to the `/wp-content/plugins/` directory.</li>
+	<li>Activate the plugin through the "Plugins" menu in WordPress.</li>
+	<li>Make sure the `wp-config.php` defines the needed constants.</li>
+</ol>
+
+<p>Example:<br>
+<br>
+<code>define('FORCE_SSL_ADMIN', true);</code><br>
+<code>define('HTTPS_DOMAIN_ALIAS', 'example.org');</code>
+</p>
+
+<p>The plugin scenario assumes the site domain is example.com but there is no https certificate for it. Instead there is a https certificate for example.org, which has been defined as the <code>HTTPS_DOMAIN_ALIAS</code>.</p>
+
+<p>In a WordPress Network installation the <code>HTTPS_DOMAIN_ALIAS</code> can be defined as *.example.org and then &lt;domain.tld&gt; will be redirected to &lt;domain&gt;.example.org. This plugin is designed to be compatible with
+the <a href="http://wordpress.org/plugins/wordpress-mu-domain-mapping/" target="_blank">WordPress MU Domain Mapping plugin</a>.</p>
+
+<p>Possible values of <code>$location</code> when calling this function
+	<ul>
+		<li>http://example.com</li>
+		<li>https://example.com &larr; the case where https fails and we want to avoid</li>
+		<li>http://example.example.org</li>
+		<li>https://example.example.org &larr; the case where https works</li>
+	</ul>
+</p>
+
+<h3>Frequently Asked Questions<h3>
+
+<h4>Does this work for WordPress Network?</h4>
+
+<p>Yes, since version 0.4.</p>
+
+<h4>Where is the UI?</h4>
+
+<p>This plugin has no visible UI, the magic happens automatically is the plugin is active.</p>
+
+<h4>What does FORCE_SSL_ADMIN do?</h4>
+
+<p>See <a href="http://codex.wordpress.org/Administration_Over_SSL" target="_blank">http://codex.wordpress.org/Administration_Over_SSL</a></p>
+
+Note that defining <code>FORCE_SSL_LOGIN</code> is not needed.
+
+<h3>Screenshots</h3>
+
+<p>Example when on <strong>coss.fi</strong> <code>HTTPS_DOMAIN_ALIAS</code> is <strong>coss.seravo.fi</strong>:<br><br>
+	<code>$ curl -I http://coss.fi/wp-admin/</code><br>
+	<code>HTTP/1.1 302 Found</code><br>
+	<code>Location: https://coss.seravo.fi/wp-admin/</code>
+</p>


### PR DESCRIPTION
This makes installation of the plugin easier by avoiding the confusion of having to read the readme after downloading from the wordpress admin add new plugins GUI.
