### PR TITLE
Fix source link of images in theme customize preview

### DIFF
--- a/https-domain-alias.php
+++ b/https-domain-alias.php
@@ -149,6 +149,9 @@ if (defined('HTTPS_DOMAIN_ALIAS')) {
   add_filter('wp_redirect', '_https_domain_rewrite');
   add_filter('plugins_url', '_https_domain_rewrite');
   add_filter('content_url', '_https_domain_rewrite');
+  add_filter('theme_mod_header_image', '_https_domain_rewrite');
+  add_filter('wp_get_attachment_url', '_https_domain_rewrite');
+  add_filter('wp_get_attachment_thumb_url', '_https_domain_rewrite');
   add_filter('site_url', '_https_domain_rewrite');
   add_filter('home_url', '_home_url_rewrite');
 


### PR DESCRIPTION
If you open the Customize link in Appearance tab in Site Admin, or when you view the blog via the domain alias, the header image don't load properly and attachment to posts gives mixed content errors.

This fixes the links of the header image and attachments so those will be loaded via the HTTPS domain alias.
