### PR TITLE
this fixes backend editor url to show the real siteurl instead of https domain alias url

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: https, ssl, tls, alias, domain, seravo
 Donate link: http://seravo.fi/
 Requires at least: 3.9.1
 Tested up to: 4.2.1
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
**After using this fix**
Instead of this:
<img width="483" alt="nayttokuva 2015-08-03 kello 19 19 54" src="https://cloud.githubusercontent.com/assets/5691777/9042052/b5529776-3a14-11e5-9383-a2b504789ed3.png">
You'll get this:
<img width="437" alt="nayttokuva 2015-08-03 kello 19 18 26" src="https://cloud.githubusercontent.com/assets/5691777/9042010/75178cac-3a14-11e5-95f4-3112a375d33f.png">

